### PR TITLE
DTSERWONE-821 - Handle HTTP 401 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 =========
+[1.0.0-beta12](https://github.com/hyperwallet/hyperwallet-android-sdk/releases/tag/1.0.0-beta12)
+-------------------
+* Handle HTTP 401
+
 [1.0.0-beta11](https://github.com/hyperwallet/hyperwallet-android-sdk/releases/tag/1.0.0-beta11)
 -------------------
 * Connection timeout increased

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We also provide an out-of-the-box  [Hyperwallet Android UI SDK](https://github.c
 To install Hyperwallet Core SDK, you just need to add the dependency into your build.gradle file in Android Studio (or Gradle). For example:
 
 ```bash
-api 'com.hyperwallet.android:core-sdk:1.0.0-beta11'
+api 'com.hyperwallet.android:core-sdk:1.0.0-beta12'
 ```
 
 ### Proguard

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
         jcenter()
         mavenLocal()
     }
-    project.version = "1.0.0-beta11"
+    project.version = "1.0.0-beta12"
 }
 
 task clean(type: Delete) {

--- a/core/src/main/java/com/hyperwallet/android/ExceptionMapper.java
+++ b/core/src/main/java/com/hyperwallet/android/ExceptionMapper.java
@@ -65,14 +65,21 @@ public final class ExceptionMapper {
      */
     public static HyperwalletException toHyperwalletException(@NonNull final Exception exception) {
         if (exception instanceof HyperwalletGqlException) {
+            HyperwalletGqlException hyperwalletGqlException = (HyperwalletGqlException) exception;
+            if (hyperwalletGqlException.getHttpCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                return initHyperwalletException(R.string.authentication_token_provider_exception,
+                        EC_AUTHENTICATION_TOKEN_PROVIDER_EXCEPTION, exception);
+            }
             return (HyperwalletGqlException) exception;
         } else if (exception instanceof HyperwalletRestException) {
             HyperwalletRestException hyperwalletRestException = (HyperwalletRestException) exception;
             if (hyperwalletRestException.getHttpCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
                 return hyperwalletRestException;
-            } else {
-                return initHyperwalletException(R.string.unexpected_exception, EC_UNEXPECTED_EXCEPTION, exception);
+            } else if (hyperwalletRestException.getHttpCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                return initHyperwalletException(R.string.authentication_token_provider_exception,
+                        EC_AUTHENTICATION_TOKEN_PROVIDER_EXCEPTION, exception);
             }
+            return initHyperwalletException(R.string.unexpected_exception, EC_UNEXPECTED_EXCEPTION, exception);
         } else if (exception instanceof HyperwalletException) {
             return (HyperwalletException) exception;
         } else if (exception instanceof IOException) {
@@ -90,7 +97,7 @@ public final class ExceptionMapper {
     }
 
     private static HyperwalletException initHyperwalletException(@StringRes int stringResourceId,
-            @NonNull final String code, @NonNull final Throwable throwable) {
+                                                                 @NonNull final String code, @NonNull final Throwable throwable) {
         Error error = new Error(stringResourceId, code);
         List<Error> errorList = new ArrayList<>();
         errorList.add(error);

--- a/core/src/main/java/com/hyperwallet/android/GqlTransaction.java
+++ b/core/src/main/java/com/hyperwallet/android/GqlTransaction.java
@@ -49,9 +49,11 @@ class GqlTransaction extends HttpTransaction {
      * @param typeReference       The class type reference to use in order to deserialize response into Hyperwallet SDK
      *                            object
      */
-    private GqlTransaction(@NonNull final String uri, @NonNull final String body,
-            @NonNull final String authenticationToken, @NonNull final HyperwalletListener hyperwalletListener,
-            @NonNull final TypeReference typeReference) {
+    private GqlTransaction(@NonNull final String uri,
+                           @NonNull final String body,
+                           @NonNull final String authenticationToken,
+                           @NonNull final HyperwalletListener hyperwalletListener,
+                           @NonNull final TypeReference typeReference) {
         super(HttpMethod.POST, uri, typeReference, hyperwalletListener);
         addHeader(HTTP_HEADER_AUTHORIZATION, AUTHENTICATION_STRATEGY + authenticationToken);
         setPayload(body);
@@ -69,11 +71,12 @@ class GqlTransaction extends HttpTransaction {
      * Refer to {@link HttpTransaction#handleErrors(int, String)}
      */
     @Override
-    protected void handleErrors(final int responseCode, @NonNull final String response) throws JSONException,
+    protected void handleErrors(final int responseCode,
+                                @NonNull final String response) throws JSONException,
             InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
         GqlErrors gqlErrors = JsonUtils.fromJsonString(response, new TypeReference<GqlErrors>() {
         });
-        onFailure(new HyperwalletGqlException(gqlErrors));
+        onFailure(new HyperwalletGqlException(responseCode, gqlErrors));
     }
 
     /**
@@ -92,15 +95,16 @@ class GqlTransaction extends HttpTransaction {
          * @param listener callback object; refer to {@link HyperwalletListener}
          */
         protected Builder(@NonNull final GqlQuery gqlQuery,
-                @NonNull final TypeReference<T> typeReference,
-                @NonNull final HyperwalletListener listener) {
+                          @NonNull final TypeReference<T> typeReference,
+                          @NonNull final HyperwalletListener listener) {
             this.gqlQuery = gqlQuery;
             this.typeReference = typeReference;
             this.listener = listener;
         }
 
-        protected GqlTransaction build(@NonNull final String uri, @NonNull final String userToken,
-                @NonNull final String authenticationToken) {
+        protected GqlTransaction build(@NonNull final String uri,
+                                       @NonNull final String userToken,
+                                       @NonNull final String authenticationToken) {
             String query = gqlQuery.toQuery(userToken);
             return new GqlTransaction(uri, query, authenticationToken, listener, typeReference);
         }

--- a/core/src/main/java/com/hyperwallet/android/exception/HyperwalletGqlException.java
+++ b/core/src/main/java/com/hyperwallet/android/exception/HyperwalletGqlException.java
@@ -35,13 +35,17 @@ import java.util.List;
  */
 public class HyperwalletGqlException extends HyperwalletException {
 
+    private final int mHttpCode;
+
     /**
      * Constructs a {@code HyperwalletGqlException} with the specified {@link GqlErrors} cause.
      *
      * @param gqlErrors the {@code GqlErrors} cause of the exception, must not be null
      */
-    public HyperwalletGqlException(@NonNull final GqlErrors gqlErrors) {
+    public HyperwalletGqlException(int httpCode, @NonNull final GqlErrors gqlErrors) {
         super();
+        mHttpCode = httpCode;
+
         List<Error> errorList = new ArrayList<>();
         List<GqlError> errors = gqlErrors.getGQLErrors();
         for (GqlError gqlError : errors) {
@@ -50,5 +54,14 @@ public class HyperwalletGqlException extends HyperwalletException {
             errorList.add(new Error(gqlError.getMessage(), code));
         }
         mErrors = new Errors(errorList);
+    }
+
+    /**
+     * Returns the HTTP response code.
+     *
+     * @return the HTTP response code
+     */
+    public int getHttpCode() {
+        return mHttpCode;
     }
 }

--- a/core/src/test/java/com/hyperwallet/android/ExceptionMapperTest.java
+++ b/core/src/test/java/com/hyperwallet/android/ExceptionMapperTest.java
@@ -70,6 +70,50 @@ public class ExceptionMapperTest {
     }
 
     @Test
+    public void testToHyperwalletException_convertRestUnauthenticatedHyperwalletException() throws Exception {
+        when(mResources.getString(R.string.authentication_token_provider_exception)).thenReturn(
+                "Authentication token retrieval attempt resulted in an error");
+        Errors errorsFromJson = JsonUtils.fromJsonString(mResourceManager.getResourceContentError(
+                        "jwt_token_expired.json"),
+                new TypeReference<Errors>() {
+                });
+        HyperwalletRestException hyperwalletException = new HyperwalletRestException(HttpURLConnection.HTTP_UNAUTHORIZED, errorsFromJson);
+        HyperwalletException hyperwalletExceptionResult = toHyperwalletException(hyperwalletException);
+        assertNotNull(hyperwalletExceptionResult);
+
+        final Errors errors = hyperwalletExceptionResult.getErrors();
+        assertNotNull(errors);
+        final List<Error> list = errors.getErrors();
+        assertThat(list, hasSize(1));
+
+        Error error = list.get(0);
+        assertThat(error.getCode(), is(equalTo("EC_AUTHENTICATION_TOKEN_PROVIDER_EXCEPTION")));
+        assertThat(error.getMessageFromResourceWhenAvailable(mResources), is(equalTo("Authentication token retrieval attempt resulted in an error")));
+    }
+
+    @Test
+    public void testToHyperwalletException_convertGqlUnauthenticatedHyperwalletException() throws Exception {
+        when(mResources.getString(R.string.authentication_token_provider_exception)).thenReturn(
+                "Authentication token retrieval attempt resulted in an error");
+        GqlErrors gqlErrors = JsonUtils.fromJsonString(mResourceManager.getResourceContentError(
+                "jwt_token_expired.json"), new TypeReference<GqlErrors>() {
+        });
+
+        HyperwalletGqlException hyperwalletException = new HyperwalletGqlException(HttpURLConnection.HTTP_UNAUTHORIZED, gqlErrors);
+        HyperwalletException hyperwalletExceptionResult = toHyperwalletException(hyperwalletException);
+        assertNotNull(hyperwalletExceptionResult);
+
+        final Errors errors = hyperwalletExceptionResult.getErrors();
+        assertNotNull(errors);
+        final List<Error> list = errors.getErrors();
+        assertThat(list, hasSize(1));
+
+        Error error = list.get(0);
+        assertThat(error.getCode(), is(equalTo("EC_AUTHENTICATION_TOKEN_PROVIDER_EXCEPTION")));
+        assertThat(error.getMessageFromResourceWhenAvailable(mResources), is(equalTo("Authentication token retrieval attempt resulted in an error")));
+    }
+
+    @Test
     public void testToHyperwalletException_convertIOException() {
         when(mResources.getString(R.string.io_exception)).thenReturn(
                 "An error that is preventing access to the required data and/or resources has occurred");
@@ -167,7 +211,8 @@ public class ExceptionMapperTest {
                 "gql_error_response.json"), new TypeReference<GqlErrors>() {
         });
 
-        HyperwalletException hyperwalletException = toHyperwalletException(new HyperwalletGqlException(gqlErrors));
+        HyperwalletException hyperwalletException = toHyperwalletException(
+                new HyperwalletGqlException(HttpURLConnection.HTTP_BAD_REQUEST, gqlErrors));
         assertNotNull(hyperwalletException);
 
         final Errors errors = hyperwalletException.getErrors();
@@ -201,26 +246,6 @@ public class ExceptionMapperTest {
         Error error = list.get(0);
         assertThat(error.getCode(), is(equalTo("SYSTEM_ERROR")));
         assertThat(error.getMessage(), is(equalTo("A system error has occurred. Please try again. If you continue to receive this error, please contact customer support for assistance (Ref ID: 99b4ad5c-4aac-4cc2-aa9b-4b4f4844ac9b).")));
-    }
-
-    @Test
-    public void testToHyperwalletRestException_convertUnmappedExceptionUnauthorized() throws Exception {
-        when(mResources.getString(R.string.unexpected_exception)).thenReturn(
-                "An unexpected error has occurred, please try again");
-        HyperwalletRestException hyperwalletRestException = new HyperwalletRestException(HttpURLConnection.HTTP_UNAUTHORIZED, null);
-        HyperwalletException hyperwalletException = toHyperwalletException(hyperwalletRestException);
-        assertNotNull(hyperwalletException);
-        assertThat(hyperwalletException, instanceOf(HyperwalletException.class));
-
-        final Errors errors = hyperwalletException.getErrors();
-        assertNotNull(errors);
-        final List<Error> list = errors.getErrors();
-        assertThat(list, hasSize(1));
-
-        Error error = list.get(0);
-        assertThat(error.getCode(), is(equalTo("EC_UNEXPECTED_EXCEPTION")));
-        assertThat(error.getMessageFromResourceWhenAvailable(mResources),
-                is(equalTo("An unexpected error has occurred, please try again")));
     }
 
     @Test

--- a/core/src/test/java/com/hyperwallet/android/RestTransactionBuilderTest.java
+++ b/core/src/test/java/com/hyperwallet/android/RestTransactionBuilderTest.java
@@ -67,7 +67,7 @@ public class RestTransactionBuilderTest {
         assertThat(headers.get("Content-Type"), is("application/json"));
         assertThat(headers.get("User-Agent"), is("HyperwalletSDK/Android/" + BuildConfig.VERSION_NAME +
                 "; App: HyperwalletSDK; Android: " + Build.VERSION.RELEASE));
-        assertThat(headers.get("X-Sdk-Version"), is("1.0.0-beta11"));
+        assertThat(headers.get("X-Sdk-Version"), is("1.0.0-beta12"));
         assertThat(headers.get("X-Sdk-Type"), is("android"));
         assertThat(headers.get("X-Sdk-ContextId"), is(notNullValue()));
         assertThat(headers.get("X-Sdk-ContextId"), is(contextId));
@@ -104,7 +104,7 @@ public class RestTransactionBuilderTest {
         assertThat(headers.get("Content-Type"), is("application/json"));
         assertThat(headers.get("User-Agent"), is("HyperwalletSDK/Android/" + BuildConfig.VERSION_NAME +
                 "; App: HyperwalletSDK; Android: " + Build.VERSION.RELEASE));
-        assertThat(headers.get("X-Sdk-Version"), is("1.0.0-beta11"));
+        assertThat(headers.get("X-Sdk-Version"), is("1.0.0-beta12"));
         assertThat(headers.get("X-Sdk-Type"), is("android"));
         assertThat(headers.get("X-Sdk-ContextId"), is(notNullValue()));
         assertThat(headers.get("X-Sdk-ContextId"), is(contextId));
@@ -140,11 +140,9 @@ public class RestTransactionBuilderTest {
         assertThat(headers.get("Content-Type"), is("application/json"));
         assertThat(headers.get("User-Agent"), is("HyperwalletSDK/Android/" + BuildConfig.VERSION_NAME +
                 "; App: HyperwalletSDK; Android: " + Build.VERSION.RELEASE));
-        assertThat(headers.get("X-Sdk-Version"), is("1.0.0-beta11"));
+        assertThat(headers.get("X-Sdk-Version"), is("1.0.0-beta12"));
         assertThat(headers.get("X-Sdk-Type"), is("android"));
         assertThat(headers.get("X-Sdk-ContextId"), is(notNullValue()));
         assertThat(headers.get("X-Sdk-ContextId"), is(contextId));
     }
 }
-
-

--- a/core/src/test/java/com/hyperwallet/android/RestTransactionTest.java
+++ b/core/src/test/java/com/hyperwallet/android/RestTransactionTest.java
@@ -1,16 +1,22 @@
 package com.hyperwallet.android;
 
+import android.content.res.Resources;
 import android.os.Handler;
 
 import com.hyperwallet.android.exception.HyperwalletException;
 import com.hyperwallet.android.exception.HyperwalletGqlException;
 import com.hyperwallet.android.listener.HyperwalletListener;
+import com.hyperwallet.android.model.Error;
+import com.hyperwallet.android.model.Errors;
 import com.hyperwallet.android.model.TypeReference;
+import com.hyperwallet.android.model.graphql.HyperwalletTransferMethodConfigurationKey;
 import com.hyperwallet.android.model.graphql.error.GqlErrors;
+import com.hyperwallet.android.model.graphql.query.TransferMethodConfigurationKeysQuery;
 import com.hyperwallet.android.model.transfermethod.BankAccount;
 import com.hyperwallet.android.rule.ExternalResourceManager;
 import com.hyperwallet.android.util.HttpClient;
 import com.hyperwallet.android.util.JsonUtils;
+import com.hyperwallet.android.sdk.R;
 
 import org.hamcrest.CoreMatchers;
 import org.json.JSONObject;
@@ -24,6 +30,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 
+import java.net.HttpURLConnection;
 import java.util.UUID;
 
 import static com.hyperwallet.android.model.transfermethod.TransferMethod.TransferMethodTypes.BANK_ACCOUNT;
@@ -32,6 +39,7 @@ import static com.hyperwallet.android.util.HttpMethod.POST;
 import static com.hyperwallet.android.util.HttpMethod.PUT;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -50,9 +58,14 @@ public class RestTransactionTest {
     private HyperwalletListener<BankAccount> mListener;
     @Mock
     private HttpClient mHttpClient;
+    @Mock
+    private Resources mResources;
+
 
     @Captor
     private ArgumentCaptor<String> mPayloadCaptor;
+    @Captor
+    private ArgumentCaptor<HyperwalletException> mExceptionArgumentCaptor;
 
     @Captor
     private ArgumentCaptor<Runnable> mRunnableCaptor;
@@ -152,7 +165,7 @@ public class RestTransactionTest {
                 "gql_error_response.json"), new TypeReference<GqlErrors>() {
         });
         when(mListener.getHandler()).thenReturn(null);
-        HyperwalletGqlException gqlException = new HyperwalletGqlException(gqlErrors);
+        HyperwalletGqlException gqlException = new HyperwalletGqlException(HttpURLConnection.HTTP_BAD_REQUEST, gqlErrors);
         restTransaction.onFailure(gqlException);
         verify(mListener).onFailure(gqlException);
     }
@@ -173,10 +186,38 @@ public class RestTransactionTest {
         });
         Handler handler = mock(Handler.class);
         when(mListener.getHandler()).thenReturn(handler);
-        HyperwalletGqlException gqlException = new HyperwalletGqlException(gqlErrors);
+        HyperwalletGqlException gqlException = new HyperwalletGqlException(HttpURLConnection.HTTP_BAD_REQUEST, gqlErrors);
         restTransaction.onFailure(gqlException);
 
         verify(handler).post(any(Runnable.class));
+    }
+
+    @Test
+    public void testHandleErrors_responseUnauthorized() throws Exception {
+        when(mResources.getString(R.string.authentication_token_provider_exception)).thenReturn(
+                "Authentication token retrieval attempt resulted in an error");
+        final PathFormatter pathFormatter = new PathFormatter("users/{0}/bank-accounts");
+        final String token = "eyJhbGciOiJIUzI1NiJ9.eyJncmFwaHFsLXVyaSI6Imh0dHA6XC9cLzEyNy4wLjAuMTo1MzEyN1wvZ3JhcGhxb";
+        String responseBody = mExternalResourceManager.getResourceContentError("jwt_token_expired.json");
+
+        TransferMethodConfigurationKeysQuery keysQuery = new TransferMethodConfigurationKeysQuery();
+
+        RestTransaction.Builder<BankAccount> accountBuilder =
+                new RestTransaction.Builder<>(GET, pathFormatter, new TypeReference<BankAccount>() {
+                }, mListener, contextId);
+        final RestTransaction restTransaction = accountBuilder
+                .build("http://hyperwallet.com/rest/v3/", token, "test-user-token");
+
+        restTransaction.handleErrors(HttpURLConnection.HTTP_UNAUTHORIZED, responseBody);
+        verify(mListener).onFailure(mExceptionArgumentCaptor.capture());
+
+        HyperwalletException exception = mExceptionArgumentCaptor.getValue();
+        assertThat(exception.getErrors().getErrors().size(), is(1));
+        Error error = exception.getErrors().getErrors().get(0);
+
+        assertThat(error.getCode(), is(equalTo("EC_AUTHENTICATION_TOKEN_PROVIDER_EXCEPTION")));
+        assertThat(error.getMessageFromResourceWhenAvailable(mResources),
+                is(equalTo("Authentication token retrieval attempt resulted in an error")));
     }
 
     @Test
@@ -210,7 +251,7 @@ public class RestTransactionTest {
         GqlErrors gqlErrors = JsonUtils.fromJsonString(mExternalResourceManager.getResourceContentError(
                 "gql_error_response.json"), new TypeReference<GqlErrors>() {
         });
-        HyperwalletGqlException gqlException = new HyperwalletGqlException(gqlErrors);
+        HyperwalletGqlException gqlException = new HyperwalletGqlException(HttpURLConnection.HTTP_BAD_REQUEST, gqlErrors);
         restTransaction.onFailure(gqlException);
 
         verify(handler).post(mRunnableCaptor.capture());
@@ -309,5 +350,4 @@ public class RestTransactionTest {
         r.run();
         verify(mListener, never()).onSuccess((BankAccount) any());
     }
-
 }

--- a/core/src/test/java/com/hyperwallet/android/model/graphql/GqlErrorMappingTest.java
+++ b/core/src/test/java/com/hyperwallet/android/model/graphql/GqlErrorMappingTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.net.HttpURLConnection;
 import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
@@ -60,7 +61,8 @@ public class GqlErrorMappingTest {
         GqlErrors gqlErrors = JsonUtils.fromJsonString(mResourceManager.getResourceContentError(
                 "gql_error_response.json"), new TypeReference<GqlErrors>() {
         });
-        HyperwalletException hyperwalletException = toHyperwalletException(new HyperwalletGqlException(gqlErrors));
+        HyperwalletException hyperwalletException = toHyperwalletException(
+                new HyperwalletGqlException(HttpURLConnection.HTTP_BAD_REQUEST, gqlErrors));
 
         assertThat(hyperwalletException, is(notNullValue()));
         final Errors errors = hyperwalletException.getErrors();

--- a/core/src/test/resources/errors/jwt_token_expired.json
+++ b/core/src/test/resources/errors/jwt_token_expired.json
@@ -1,0 +1,8 @@
+{
+  "errors":[
+    {
+      "message":"JWT expired",
+      "code":"JWT_EXPIRED"
+    }
+  ]
+}


### PR DESCRIPTION
The Hyperwallet SDK can receive unauthorized (HTTP 401) response from the Hyperwallet API due the client change the password from the consumer UI, the core is bubble up HTTP error as Unexpected error.

This PR will bubble up HTTP 401 error as Authentication error.

Enhanced Hyperwallet Error to handle 401
Introduce test by performing Rest and GraphQL call to handle 401